### PR TITLE
Add "address_index" information to SubAddress instances

### DIFF
--- a/monero/address.py
+++ b/monero/address.py
@@ -143,7 +143,7 @@ class SubAddress(BaseAddress):
         if addr_index:
             if not isinstance(addr_index, int) or not addr_index > 0:
                 raise ValueError(
-                    "SubAddress index must be an integer bigger then 0"
+                    "SubAddress index must be an integer bigger than 0"
                 )
 
         super().__init__(addr, label)

--- a/monero/address.py
+++ b/monero/address.py
@@ -138,6 +138,17 @@ class SubAddress(BaseAddress):
     _valid_netbytes = (42, 63, 36)
     # NOTE: _valid_netbytes order is (mainnet, testnet, stagenet)
 
+    def __init__(self, addr, addr_index=None, label=None):
+        """SubAddress instance can optionally have the index information."""
+        if addr_index:
+            if not isinstance(addr_index, int) or not addr_index > 0:
+                raise ValueError(
+                    "SubAddress index must be an integer bigger then 0"
+                )
+
+        super().__init__(addr, label)
+        self.index = addr_index
+
     def with_payment_id(self, _):
         raise TypeError("SubAddress cannot be integrated with payment ID")
 
@@ -175,7 +186,7 @@ class IntegratedAddress(Address):
         return Address(base58.encode(hexlify(data + checksum)))
 
 
-def address(addr, label=None):
+def address(addr, index=None, label=None):
     """Discover the proper class and return instance for a given Monero address.
 
     :param addr: the address as a string-like object
@@ -189,7 +200,7 @@ def address(addr, label=None):
         if netbyte in Address._valid_netbytes:
             return Address(addr, label=label)
         elif netbyte in SubAddress._valid_netbytes:
-            return SubAddress(addr, label=label)
+            return SubAddress(addr, addr_index=index, label=label)
         raise ValueError("Invalid address netbyte {nb:x}. Allowed values are: {allowed}".format(
             nb=netbyte,
             allowed=", ".join(map(

--- a/monero/backends/jsonrpc.py
+++ b/monero/backends/jsonrpc.py
@@ -171,13 +171,14 @@ class JSONRPCWallet(object):
         for _addr in _addresses['addresses']:
             addresses[_addr['address_index']] = address(
                 _addr['address'],
+                index=_addr['address_index'],
                 label=_addr.get('label', None))
         return addresses
 
     def new_address(self, account=0, label=None):
         _address = self.raw_request(
             'create_address', {'account_index': account, 'label': label})
-        return SubAddress(_address['address'])
+        return SubAddress(_address['address'], _address['address_index'])
 
     def balances(self, account=0):
         _balance = self.raw_request('getbalance', {'account_index': account})

--- a/tests/test_address.py
+++ b/tests/test_address.py
@@ -148,6 +148,19 @@ class Tests(object):
         sa = SubAddress(self.subaddr)
         self.assertRaises(TypeError, sa.with_payment_id, self.pid)
 
+    def test_subaddress_invalid_index(self):
+        self.assertRaises(ValueError, SubAddress, (self.subaddr, 0))
+        self.assertRaises(ValueError, SubAddress, (self.subaddr, -1))
+        self.assertRaises(ValueError, SubAddress, (self.subaddr, "other_type"))
+
+    def test_subaddress_valid_index(self):
+        sa1 = SubAddress(self.subaddr, 1)
+        self.assertEqual(sa1.index, 1)
+        sa2 = SubAddress(self.subaddr, 2)
+        self.assertEqual(sa2.index, 2)
+        sa3 = SubAddress(self.subaddr, 200)
+        self.assertEqual(sa3.index, 200)
+
 
 class AddressTestCase(Tests, unittest.TestCase):
     addr = '47ewoP19TN7JEEnFKUJHAYhGxkeTRH82sf36giEp9AcNfDBfkAtRLX7A6rZz18bbNHPNV7ex6WYbMN3aKisFRJZ8Ebsmgef'


### PR DESCRIPTION
Fixes issue #3 

This pull request fixes the issue with  `address_index` information not being stored on `SubAddress`. 
There might be other occurrences that I wasn't able to find, but at least in 2 use cases this new information was added. 

`address_index` was added as an optional parameter to avoid breaking existing code.