### PR TITLE
Add optional timeout to JSON-RPC daemon/wallet

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,6 +21,8 @@ This fork contains the following changes:
 * Dropped support for python 2.
 * Added: ``get_unspent_outputs`` and ``get_incoming_transactions`` to the wallet.
 * Added: ``address_index`` to instances of ``SubAddress``.
+* Added: optional ``timeout`` to ``JSONRPCWallet`` and ``JSONRPCDaemon``.  Please note that
+  a timeout does not mean that the underlying operation was not executed.
 
 For documentation about how to use the package please check the original repository.
 


### PR DESCRIPTION
This PR adds a `timeout` argument to `JSONRPCWallet` and `JSONRPCDaemon` which is applied to all requests, fixing #18. The timeout defaults to `None` so this change is backwards compatible.

The timeout is passed directly to `requests.post` so it can be simply a number of seconds or a  `(connect timeout, read timeout)` tuple (see https://3.python-requests.org/user/advanced/#timeouts).

No special exceptions are raised. If needed, the caller will have to handle the `Timeout` exception from `requests`, similarly to what currently happens for other types of connection errors.